### PR TITLE
QE-159

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -22,11 +22,14 @@ jobs:
         - uses: actions/download-artifact@v3
           with:
             name: ${{ inputs.coverage_artifact }}
-        # If artifact is `coverage.json | .resultset.json ` update file
-        # bug in SonarQube when parsing ruby coverage reports need to change the path location
-        # in the file or else no coverage data will display in SonarQube
-        - name: Parse file
-          if: inputs.coverage_artifact == 'coverage.json' || inputs.coverage_artifact == '.resultset.json'
+        # SonarQube bug - If artifact is `coverage.json | .resultset.json ` the file needs to be edited
+        # bug in SonarQube GHA scanner when parsing for ruby coverage reports
+        # the path value is incorrect in the coverage report and not pointing to the correct 
+        # directory where the source code lives in within the Github actions agent
+        # When scan is complete the code coverage does not display on SonarQube and warning logs
+        # are displayed in the command output within the github agent.
+        # Fix - updated the path value within the file if it is either `coverage.json | .resultset.json `
+        - if: inputs.coverage_artifact == 'coverage.json' || inputs.coverage_artifact == '.resultset.json'
           run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' $COVERAGE_REPORT
         # Performs the SonarQube static code analysis scan
         - uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -27,10 +27,7 @@ jobs:
         # in the file or else no coverage data will display in SonarQube
         - name: Parse file
           if: inputs.coverage_artifact == 'coverage.json' || inputs.coverage_artifact == '.resultset.json'
-          run: |
-            ls -a
-            pwd
-            sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' $COVERAGE_REPORT
+          run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' $COVERAGE_REPORT
         # Performs the SonarQube static code analysis scan
         - uses: sonarsource/sonarqube-scan-action@master
           env:

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   static_code_analysis:
         runs-on: ubuntu-latest
+        env:
+          COVERAGE_REPORT: ${{ inputs.coverage_artifact }}
         steps:
         # Checkouts the github repository
         - uses: actions/checkout@v2
@@ -20,6 +22,15 @@ jobs:
         - uses: actions/download-artifact@v3
           with:
             name: ${{ inputs.coverage_artifact }}
+        # If artifact is `coverage.json | .resultset.json ` update file
+        # bug in SonarQube when parsing ruby coverage reports need to change the path location
+        # in the file or else no coverage data will display in SonarQube
+        - name: Parse file
+          if: inputs.coverage_artifact == coverage.xml || inputs.coverage_artifact == .resultset.json
+          run: |
+            ls -a
+            pwd
+            sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' $COVERAGE_REPORT
         # Performs the SonarQube static code analysis scan
         - uses: sonarsource/sonarqube-scan-action@master
           env:

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -26,7 +26,7 @@ jobs:
         # bug in SonarQube when parsing ruby coverage reports need to change the path location
         # in the file or else no coverage data will display in SonarQube
         - name: Parse file
-          if: inputs.coverage_artifact == coverage.xml || inputs.coverage_artifact == .resultset.json
+          if: inputs.coverage_artifact == 'coverage.xml' || inputs.coverage_artifact == '.resultset.json'
           run: |
             ls -a
             pwd

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -26,7 +26,7 @@ jobs:
         # bug in SonarQube when parsing ruby coverage reports need to change the path location
         # in the file or else no coverage data will display in SonarQube
         - name: Parse file
-          if: inputs.coverage_artifact == 'coverage.xml' || inputs.coverage_artifact == '.resultset.json'
+          if: inputs.coverage_artifact == 'coverage.json' || inputs.coverage_artifact == '.resultset.json'
           run: |
             ls -a
             pwd


### PR DESCRIPTION
**Description**
For ruby coverage reports there is a bug in SonarQubes github action https://github.com/SonarSource/sonarqube-scan-action. Depending on the version of **simplecov** used to generate the coverage reports the reports has multiple paths within the file 
```json
{
  "coverage": {
    "/home/runner/work/shipment-tracking-service/shipment-tracking-service/Rakefile": {
    },
}
```
The prefix path **/home/runner/work/** is where the files are located for the repo on the Jenkins agent. However when executing the GHA for sonar scanner the scanner exists in the **/github/workspace/**. and once the scan is done we see warnings in the log output like such:
![image](https://user-images.githubusercontent.com/22439603/174495105-d21784ce-b7f0-4e1b-a0f7-d5e695347744.png)

This is a bug in SonarSources scanner. In order to resolve this issue without having to wait on the fix from the SonarSource team I have updated the github action to edit the paths of the ruby coverage report files so that we can see coverage displayed for ruby projects.
